### PR TITLE
fix: failing build 🐛

### DIFF
--- a/src/components/snackbar/index.ts
+++ b/src/components/snackbar/index.ts
@@ -1,1 +1,2 @@
-export {KeyActionSnackbar, IKeyActionSnackbar} from "./key-action-snackbar/KeyActionSnackbar";
+export {KeyActionSnackbar} from "./key-action-snackbar/KeyActionSnackbar";
+export type { IKeyActionSnackbar} from "./key-action-snackbar/KeyActionSnackbar";


### PR DESCRIPTION
fix: failing build by changing the imports to fit rollup style of code splitting 🐛