### PR TITLE
search-bar-operator-cy-149

### DIFF
--- a/src/components/search-bar-operand/styles/SSearchBarOperand.tsx
+++ b/src/components/search-bar-operand/styles/SSearchBarOperand.tsx
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components';
-import { CSSProgressiveCaption01Semibold } from '../../../constants/styles/fonts';
+import { CSSProgressiveCaption01Semibold } from '../../../constants/styles/design-tokens/fonts/CSSTypographies';
 import { MIN_DIAMOND, MIN_GOLD, MIN_PLATINUM, MIN_SILVER } from '../../../constants/styles/mediaquerys';
 import { ISearchBarOperandProps } from '../SearchBarOperand';
 

--- a/src/components/search-bar-operand/styles/SSearchBarOperand.tsx
+++ b/src/components/search-bar-operand/styles/SSearchBarOperand.tsx
@@ -15,7 +15,7 @@ const CSSActivated = css`
 `;
 
 const Bronze = css<ISearchBarOperandProps>`
-  ${ProgressiveCaption01Semibold};
+  ${CSSProgressiveCaption01Semibold};
   height: 28px;
   color: var(--active-ui-01);
   flex-grow: 0;

--- a/src/components/searchbar-operator/styles/SSearchBarOperator.tsx
+++ b/src/components/searchbar-operator/styles/SSearchBarOperator.tsx
@@ -1,5 +1,5 @@
 import styled, { css } from "styled-components";
-import { CSSProgressivehighLightMicro } from "../../../constants/styles/fonts";
+import { CSSProgressiveHighlightMicro } from "../../../constants/styles/design-tokens/fonts/CSSTypographies";
 import { MIN_DIAMOND, MIN_GOLD, MIN_PLATINUM, MIN_SILVER } from "../../../constants/styles/mediaquerys";
 import { ISearchBarOperatorProps } from "../SearchBarOperator";
 
@@ -11,13 +11,13 @@ const CSSHover = css`
 
 const CSSActive = css`
   background-color: white;
-  color: var(--ui-supportive-03);
-  outline: 1px solid var(--ui-supportive-03);
+  color: var(--active-text-04);
+  outline: 1px solid var(--active-text-04);
   outline-offset: -1px;
 `;
 
 const Bronze = css<ISearchBarOperatorProps>`
-  ${CSSProgressivehighLightMicro};
+  ${CSSProgressiveHighlightMicro};
   color: var(--text-04);
   text-transform: uppercase;
   max-width: min-content;

--- a/src/components/searchbar-operator/styles/SSearchBarOperator.tsx
+++ b/src/components/searchbar-operator/styles/SSearchBarOperator.tsx
@@ -20,7 +20,6 @@ const Bronze = css<ISearchBarOperatorProps>`
   ${CSSProgressiveHighlightMicro};
   color: var(--text-04);
   text-transform: uppercase;
-  max-width: min-content;
   height: 1.3 rem;
   box-sizing: border-box;
   background-color: var(--ui-03);

--- a/src/components/searchbar-operator/styles/SSearchBarOperatorWrapper.tsx
+++ b/src/components/searchbar-operator/styles/SSearchBarOperatorWrapper.tsx
@@ -7,7 +7,7 @@ const CSSHover = css`
 `;
 
 const CSSActive = css`
-  border-color: var(--ui-supportive-03);
+  border-color: var(--active-text-04);
 `;
 
 const Bronze = css<ISearchBarOperatorProps>`

--- a/src/components/sidebar-card/styles/SSidebarCardTitle.tsx
+++ b/src/components/sidebar-card/styles/SSidebarCardTitle.tsx
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components';
-import { CSSProgressiveCaption01Semibold } from '../../../constants/styles/fonts';
+import { CSSProgressiveCaption01Semibold } from '../../../constants/styles/design-tokens/fonts/CSSTypographies';
 import { MIN_SILVER, MIN_GOLD, MIN_PLATINUM, MIN_DIAMOND } from '../../../constants/styles/mediaquerys';
 
 const Bronze = css`


### PR DESCRIPTION
This fixes a bug that we just found with "max-height: min-content" which does not work properly for firefox