### PR TITLE
badges-cy-109

### DIFF
--- a/src/components/badge/Badge.stories.jsx
+++ b/src/components/badge/Badge.stories.jsx
@@ -74,7 +74,7 @@ export const PositionCenter = ({ content, ...args }) => (
 PositionCenter.args = {
   type: "regular",
   value: "1",
-  size: "small"
+  size: "micro"
 };
 
 // Type color

--- a/src/components/badge/Badge.tsx
+++ b/src/components/badge/Badge.tsx
@@ -17,7 +17,6 @@ export interface IBadgeProps {
 }
 
 export const Badge: FC<IBadgeProps> = forwardRef(({ children, value, position, type, size }: IBadgeProps, ref: any) => {
-  
   const badgeRef = useRef<HTMLElement>(null);
   const [width, setWidth] = React.useState(0);
   // calculate width of the badge
@@ -25,9 +24,7 @@ export const Badge: FC<IBadgeProps> = forwardRef(({ children, value, position, t
     const badgeWidth = badgeRef.current ? badgeRef.current.offsetWidth : 0;
     setWidth(badgeWidth);
   }, [value, badgeRef.current]);
-  
-  console.log(width);
-  
+
   return (
     <SBadge ref={ref}>
       <SBadgeIcon ref={badgeRef} value={value} position={position} type={type} size={size} width={width}>

--- a/src/components/badge/styles/SBadgeIcon.tsx
+++ b/src/components/badge/styles/SBadgeIcon.tsx
@@ -1,9 +1,9 @@
 import styled, { css } from "styled-components";
 import { ISizes } from "../../../interfaces/index";
-import { CSSProgressiveBadgesSmall } from "../../../constants/styles/fonts";
 import { MIN_DIAMOND, MIN_GOLD, MIN_PLATINUM, MIN_SILVER } from "../../../constants/styles/mediaquerys";
 import { IBadgeType } from "../Badge";
 import { EBadgePosition } from "../EBadgePosition";
+import { CSSProgressiveHighlight } from "../../../constants/styles/design-tokens/fonts/CSSTypographies";
 
 interface ISBadgeIcon {
   position: EBadgePosition;
@@ -78,7 +78,8 @@ const CSSMedium = css<{ width: number }>`
 
 const Bronze = css<ISBadgeIcon>`
   position: absolute;
-  ${CSSProgressiveBadgesSmall}
+  ${CSSProgressiveHighlight};
+  font-family: "Inter";
   z-index: 10;
   height: 0.75rem;
   color: var(--ui-01);

--- a/src/components/badge/styles/SBadgeIconContent.tsx
+++ b/src/components/badge/styles/SBadgeIconContent.tsx
@@ -7,14 +7,17 @@ const CSSDisplayNone = css`
 
 const CSSMicro = css`
   font-size: 0.5rem;
+  line-height: 0.5rem;
 `;
 
 const CSSSmall = css`
   font-size: 0.563rem;
+  line-height: 0.563rem;
 `;
 
 const CSSMedium = css`
   font-size: 0.688rem;
+  line-height: 0.688rem;
 `;
 
 const Bronze = css`


### PR DESCRIPTION
In QA we noticed that the badge component still has some issues. 
- the font family was arial (could not find out why) -> added "Inter"
- esp in micro size the font did not sit centered -> added line height property

from storybook:
![Bildschirmfoto 2021-12-16 um 09 58 58](https://user-images.githubusercontent.com/93647258/146340224-f30cfc2d-9496-4195-b53b-3f0411c21796.png)
from figma:
![Bildschirmfoto 2021-12-16 um 09 59 28](https://user-images.githubusercontent.com/93647258/146340291-7814e0b1-41c8-43ac-95d4-825f0e19976f.png)

