### PR TITLE
fix-add-props-to-solid-label-component-cy-579

### DIFF
--- a/src/components/solidLabel/SolidLabel.stories.tsx
+++ b/src/components/solidLabel/SolidLabel.stories.tsx
@@ -29,9 +29,9 @@ export default {
     }  
 };
 
-function SolidLabelDemo({ content, ...args }) {
+function SolidLabelDemo({ content, type }) {
   return (
-    <SolidLabel {...args}>
+    <SolidLabel type={type}>
       <span>{content}</span>
     </SolidLabel>
   );

--- a/src/components/solidLabel/SolidLabel.tsx
+++ b/src/components/solidLabel/SolidLabel.tsx
@@ -7,12 +7,13 @@ export interface ISolidLabelProps {
   type?: ISolidLabelType;
   style?: object;
   onClick?: () => void;
+  children?
 }
 
-export const SolidLabel: React.FC = (props) => {
+export const SolidLabel: React.FC<ISolidLabelProps> = ({ type, children }) => {
   return (
-    <SSolidLabel {...props}>
-      {props.children}
+    <SSolidLabel type={type}>
+      {children}
     </SSolidLabel>
   );
 };


### PR DESCRIPTION
Problem: I wanted to use the Solid Label component in list status item but was not able to acces the type prop and therefore change the style of the label. 

I tried it out on my branch and it seems that adding the interface after React.FC fixes the issue.