### PR TITLE
create-sub-components-to-be-used-to-cy-690

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ out
 sb-out.txt
 storybook-static
 yarn-error.log
+.idea

--- a/src/components/list-item/ListItem.stories.tsx
+++ b/src/components/list-item/ListItem.stories.tsx
@@ -1,20 +1,10 @@
-import { ListItem } from "./ListItem";
-import { IconChevronRight, IconDragable, IconGearSettings, IconPin, IconStarOutlined } from "../../icons";
-import { useState } from "react";
-
-function ListItemDemo({ children, activated, onClick, ...props }) {
-  return (
-    <div {...props} style={{ width: 320 }}>
-      <ListItem activated={activated} onClick={onClick}>
-        {children}
-      </ListItem>
-    </div>
-  );
-}
+import {ListItem} from "./ListItem";
+import {IconChevronRight, IconDragable, IconGearSettings, IconPin, IconStarOutlined} from "../../icons";
+import {useState} from "react";
 
 export default {
   title: "Components/Interactional/ListItem",
-  component: ListItemDemo,
+  component: ListItem,
   parameters: {
     design: {
       type: "figma",
@@ -23,33 +13,21 @@ export default {
   },
 };
 
-const SmallListItemTemplate = ({ showLeftIcon, showRightIcon, content }) => {
+const SmallListItemTemplate = ({showLeftIcon, showRightIcon, content}) => {
   const [activated, setActivated] = useState(false);
-
+  
   const toggleActivated = () => {
     setActivated((prev) => !prev);
   };
-
+  
   return (
-    <ListItemDemo onClick={toggleActivated} activated={activated}>
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: 8,
-        }}
-      >
-        <div style={{ display: "flex", alignItems: "center", justifyContent: "center" }}>
-          {showLeftIcon && <IconStarOutlined size={16} />}
-        </div>
-        <p style={{ width: 200, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{content}</p>
-      </div>
+    <ListItem onClick={toggleActivated} activated={activated}>
+      {showLeftIcon && <IconStarOutlined size={16}/>}
+      <p data-main>{content}</p>
       {showRightIcon && (
-        <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", justifyContent: "center" }}>
-          <IconChevronRight size={16} />
-        </div>
+        <IconChevronRight size={16}/>
       )}
-    </ListItemDemo>
+    </ListItem>
   );
 };
 
@@ -60,36 +38,28 @@ SmallListItem.args = {
   content: "Default",
 };
 
-const ListSpoilerTemplate = ({ showLeftIcon, showRightIcon, content }) => {
+const ListSpoilerTemplate = ({showLeftIcon, showRightIcon, content}) => {
   const [activated, setActivated] = useState(false);
-
+  
   const toggleActivated = () => {
     setActivated((prev) => !prev);
   };
   return (
-    <ListItemDemo onClick={toggleActivated} activated={activated}>
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          marginRight: 8,
-          transform: `rotate(${activated ? "90deg" : "0"})`,
-          transition: "transform 200ms",
-        }}
-      >
-        <IconChevronRight size={16} />
+    <ListItem onClick={toggleActivated} activated={activated}>
+      <div style={{
+        display: "flex",
+        transformOrigin: 'center',
+        transform: `rotate(${activated ? "90deg" : "0"})`,
+        transition: "transform 200ms",
+      }}>
+        <IconChevronRight size={16}/>
       </div>
-      <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 8 }}>
-        {showLeftIcon && <IconStarOutlined size={16} />}
-        <p style={{ width: 200, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{content}</p>
-      </div>
+      {showLeftIcon && <IconStarOutlined size={16}/>}
+      <p data-main>{content}</p>
       {showRightIcon && (
-        <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", justifyContent: "center" }}>
-          <IconStarOutlined size={16} />
-        </div>
+        <IconStarOutlined size={16}/>
       )}
-    </ListItemDemo>
+    </ListItem>
   );
 };
 
@@ -100,34 +70,27 @@ ListSpoiler.args = {
   content: "Default",
 };
 
-const ViewSectionTemplate = ({ content }) => {
+const ViewSectionTemplate = ({content}) => {
   const [activated, setActivated] = useState(false);
-
+  
   const toggleActivated = () => {
     setActivated((prev) => !prev);
   };
   return (
-    <ListItemDemo onClick={toggleActivated} activated={activated}>
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          marginRight: 8,
-          transform: `rotate(${activated ? "90deg" : "0"})`,
-          transition: "transform 200ms",
-        }}
-      >
-        <IconChevronRight size={16} />
+    <ListItem onClick={toggleActivated} activated={activated}>
+      <div style={{
+        display: "flex",
+        transformOrigin: "center",
+        transform: `rotate(${activated ? "90deg" : "0"})`,
+        transition: "transform 200ms",
+      }}>
+        <IconChevronRight size={16}/>
       </div>
-      <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 8 }}>
-        🤘 <p style={{ width: 200, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{content}</p>
-      </div>
-      <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", justifyContent: "center", gap: 8 }}>
-        <IconGearSettings size={16} />
-        <IconDragable size={16} />
-      </div>
-    </ListItemDemo>
+      🤘
+      <p data-main>{content}</p>
+      <IconGearSettings size={16}/>
+      <IconDragable size={16}/>
+    </ListItem>
   );
 };
 
@@ -136,34 +99,19 @@ ViewSection.args = {
   content: "Default",
 };
 
-const ViewListItemTemplate = ({ content }) => {
+const ViewListItemTemplate = ({content}) => {
   const [hover, setHover] = useState(false);
   const [activated, setActivated] = useState(false);
   return (
-    <ListItemDemo
+    <ListItem
       onClick={() => setActivated((prev) => !prev)}
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
       activated={activated}
     >
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          marginLeft: 28,
-          fontWeight: 400,
-          fontSize: 14,
-        }}
-      >
-        <p style={{ width: 200, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{content}</p>{" "}
-      </div>
-      {(hover || activated) && (
-        <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", justifyContent: "center" }}>
-          <IconPin size={12} />
-        </div>
-      )}
-    </ListItemDemo>
+      <p data-main>{content}</p>{" "}
+      {(hover || activated) && (<IconPin size={16}/>)}
+    </ListItem>
   );
 };
 

--- a/src/components/list-item/ListItem.tsx
+++ b/src/components/list-item/ListItem.tsx
@@ -1,14 +1,13 @@
-import React, { FC } from "react";
+import React, { FC, AllHTMLAttributes } from "react";
 import { SListItem } from "./styles/SListItem";
 
 interface IListItem {
   activated?: boolean;
-  onClick?: () => void;
 }
 
-export const ListItem: FC<IListItem> = ({ children, activated, onClick }) => {
+export const ListItem: FC<IListItem & AllHTMLAttributes<HTMLElement>> = ({ children, activated, ...props }) => {
   return (
-    <SListItem onClick={onClick} activated={activated}>
+    <SListItem activated={activated} {...props}>
       {children}
     </SListItem>
   );

--- a/src/components/list-item/styles/SListItem.tsx
+++ b/src/components/list-item/styles/SListItem.tsx
@@ -24,6 +24,18 @@ const Bronze = css`
 
   display: flex;
   align-items: center;
+  gap: 8px;
+  *{
+    flex: 0 0 auto;
+  }
+  
+  [data-main]{
+    flex-shrink: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    margin-right: auto;
+  }
 
   &:hover {
     ${CSSHover}


### PR DESCRIPTION
@diegomart2000 
as we discussed the `ListItem`, I initially created a separate styled component for the left and right sides,

but I found that if we just can know the main part of the list item so we can get rid of all the inline styling and so I used `data-main` to mark this part and it worked perfectly 😃.

I updated the storybook and the docs are working perfectly.