### PR TITLE
fix: remove extra div wrapper around LineTabPanel & fix storybook docs

### DIFF
--- a/src/components/line-tabs/LineTabs.stories.jsx
+++ b/src/components/line-tabs/LineTabs.stories.jsx
@@ -1,52 +1,11 @@
 import React, { useState } from "react";
+import {IconStarOutlined} from "../../icons";
 import { Button } from "../button";
 import { LineTabs, LineTabPanel } from "./LineTabs";
-import { IconStarOutlined } from "../../icons/IconStarOutlined";
-
-function LineTabsShowcase() {
-  const [currentTab, setCurrentTab] = useState(0);
-
-  return (
-    <div
-      style={{
-        display: "flex",
-        padding: "32px 60px",
-        flexWrap: "wrap",
-        backgroundColor: "var(--ui-01)",
-        boxShadow: "0 10px 30px 0 rgba(89, 106, 122, 0.11)",
-        borderRadius: "5px",
-      }}
-    >
-      <div style={{ width: "100%" }}>
-        <LineTabs
-          initialValue={currentTab}
-          onChange={(newValue) => {
-            if (newValue != currentTab) {
-              setCurrentTab(newValue);
-            }
-          }}
-        >
-          <LineTabPanel title="Tab 1" icon={<IconStarOutlined></IconStarOutlined>}>
-            This is the first panelThis is the first panelThis is the first panelThis is the first panelThis is the
-            first panel
-          </LineTabPanel>
-          <LineTabPanel title="Tab 2">This is the second panel</LineTabPanel>
-          <LineTabPanel title="Tab 3">This is the third panel</LineTabPanel>
-        </LineTabs>
-        <br />
-        <p>Current tab: {currentTab}</p>
-        <br />
-        <Button size="small" onClick={() => setCurrentTab((currentTab + 1) % 3)}>
-          Change to next tab
-        </Button>
-      </div>
-    </div>
-  );
-}
 
 export default {
   title: "Components/Navigation/LineTabs",
-  component: LineTabsShowcase,
+  component: LineTabs,
   parameters: {
     design: {
       type: "figma",
@@ -55,7 +14,42 @@ export default {
   },
 };
 
-const Template = (args) => <LineTabsShowcase {...args} />;
+const Template = (args) => {
+  const [currentTab, setCurrentTab] = useState(0);
+  
+  return (
+      <div
+          style={{
+            display: "flex",
+            padding: "32px 60px",
+            flexWrap: "wrap",
+            backgroundColor: "var(--ui-01)",
+            boxShadow: "0 10px 30px 0 rgba(89, 106, 122, 0.11)",
+            borderRadius: "5px",
+          }}
+      >
+        <div style={{ width: "100%" }}>
+          <LineTabs
+              initialValue={currentTab}
+              onChange={(newValue) => setCurrentTab(newValue)}
+          >
+            <LineTabPanel title="Tab 1" icon={<IconStarOutlined/>}>
+              This is the first panelThis is the first panelThis is the first panelThis is the first panelThis is the
+              first panel
+            </LineTabPanel>
+            <LineTabPanel title="Tab 2">This is the second panel</LineTabPanel>
+            <LineTabPanel title="Tab 3">This is the third panel</LineTabPanel>
+          </LineTabs>
+          <br />
+          <p>Current tab: {currentTab}</p>
+          <br />
+          <Button size="small" onClick={() => setCurrentTab((currentTab + 1) % 3)}>
+            Change to next tab
+          </Button>
+        </div>
+      </div>
+  );
+}
 
 export const Default = Template.bind({});
 Default.args = {};

--- a/src/components/line-tabs/LineTabs.tsx
+++ b/src/components/line-tabs/LineTabs.tsx
@@ -46,9 +46,8 @@ export const LineTabs: React.FC<ILineTabs> = (props) => {
         ) : (
           <div>Loading...</div>
         )
-      ) : (
-        <div>{React.Children.map(props.children, (child, i) => (i === selected ? child : null))}</div>
-      )}
+      ) :
+        React.Children.map(props.children, (child, i) => (i === selected ? child : null))}
     </SLineTabs>
   );
 };


### PR DESCRIPTION
as `LineTabPanel` component accepts `style` prop the extra div wrapper misses with this styling

so I removed it as it is not needed in the first place