### PR TITLE
bug-profile-active-menu-is-missing-cy-923

### DIFF
--- a/src/components/line-tab/styles/SLineTabLine.ts
+++ b/src/components/line-tab/styles/SLineTabLine.ts
@@ -6,6 +6,7 @@ const Bronze = css`
   width: 100%;
   position: absolute;
   bottom: 0.5px;
+  z-index: 1;
 `;
 
 const Silver = css``;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/93647258/157877007-d188e8f2-3f0d-42a6-8ac6-20c4730a92e5.png)
the line below the line input needed a z-index (it's 1 now) so it would show up correctly in web app