### PR TITLE
improvement-badge-components

### DIFF
--- a/src/components/badge/Badge.tsx
+++ b/src/components/badge/Badge.tsx
@@ -36,7 +36,7 @@ export const Badge: FC<IBadgeProps> = forwardRef(({ children, value, position, t
         type={type}
         size={size}
         width={width}
-        withPadding={value?.length > 1 && type !== "color" && /[A-Za-z]/.test(value)}
+        withPadding={value?.length > 1 && type !== "color" && /[A-Za-z0-9]/.test(value)}
         withBorder={withBorder}
       >
         <SBadgeIconContent type={type} size={size}>


### PR DESCRIPTION
The regex condition that applies padding didn't include numbers
![comp](https://github.com/caisy-io/league/assets/131889080/d9c501d0-fb0e-4eb6-8fd5-96b5c073569b)
